### PR TITLE
Add in/nin operators for expressions

### DIFF
--- a/b3j0f/requester/request/consts.py
+++ b/b3j0f/requester/request/consts.py
@@ -86,6 +86,7 @@ class FuncName(Enum):
     ISNULL = 'isnull'
     BETWEEN = 'between'
     IN = 'in'
+    NIN = 'nin'
 
     # selection operators  TODO: might be migrated to the Read object...
     HAVING = 'having'

--- a/b3j0f/requester/request/expr.py
+++ b/b3j0f/requester/request/expr.py
@@ -119,6 +119,10 @@ class Expression(BaseElement):
 
         return type(self)(name='{0}.{1}'.format(self.name, key))
 
+    def __not__(self, other):
+
+        return Function(FuncName.NOT)(self, other)
+
     def __and__(self, other):
 
         return Function(FuncName.AND)(self, other)

--- a/b3j0f/requester/request/expr.py
+++ b/b3j0f/requester/request/expr.py
@@ -119,10 +119,6 @@ class Expression(BaseElement):
 
         return type(self)(name='{0}.{1}'.format(self.name, key))
 
-    def __not__(self, other):
-
-        return Function(FuncName.NOT)(self, other)
-
     def __and__(self, other):
 
         return Function(FuncName.AND)(self, other)

--- a/b3j0f/requester/request/expr.py
+++ b/b3j0f/requester/request/expr.py
@@ -271,6 +271,10 @@ class Expression(BaseElement):
 
         return Function(FuncName.ABS)(self)
 
+    def __contains__(self, other):
+        
+        return Function(FuncName.IN)(self, other)
+
     def __pow__(self, other):
 
         self._checktype(other, Number)

--- a/b3j0f/requester/request/test/expr.py
+++ b/b3j0f/requester/request/test/expr.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2016 Jonathan Labéjof <jonathan.labejof@gmail.com>
+# Copyright (c) 2016 Jonathan Labéjof <jonathan.labejof@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -304,6 +304,14 @@ class ExpressionTest(UTCase):
         func = abs(expr)
 
         self._assertfunc(func, FuncName.ABS, expr)
+
+    def test__contains__(self):
+
+        expr = Expression(name='')
+
+        func = expr.__contains__('')
+
+        self._assertfunc(func, FuncName.IN, expr, '')
 
     def test__mod__(self):
 


### PR DESCRIPTION
Rajout de la méthode __contains__ et de la référence à l'opérateur NIN pour les expressions.