### PR TITLE
Bugfix create update repr

### DIFF
--- a/b3j0f/requester/request/crud/create.py
+++ b/b3j0f/requester/request/crud/create.py
@@ -3,7 +3,7 @@
 # --------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2016 Jonathan Labéjof <jonathan.labejof@gmail.com>
+# Copyright (c) 2016 Jonathan Labéjof <jonathan.labejof@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -53,7 +53,12 @@ class Create(CRUDElement):
 
     def __repr__(self):
 
-        result = 'CREATE {0}:{1}'.format(repr(self.name), repr(self.values))
+        result = 'CREATE '
+
+        if self.name:
+            result += '{0}:'.format(repr(self.name))
+
+        result += repr(self.values)
 
         if self.query:
             result += ' where ({0})'.format(repr(self.query))

--- a/b3j0f/requester/request/crud/test/create.py
+++ b/b3j0f/requester/request/crud/test/create.py
@@ -31,6 +31,7 @@ from unittest import main
 
 from b3j0f.utils.ut import UTCase
 
+from ...expr import Expression as E
 from ..create import Create
 
 
@@ -44,6 +45,59 @@ class CreateTest(UTCase):
 
         self.assertEqual('test', create.name)
         self.assertEqual(values, create.values)
+
+    def test___repr__(self):
+        cases = [
+            {
+                'values': {},
+                'name': E.c,
+                'where': None,
+                'as': None,
+                'expected': "CREATE c:{}",
+            },
+            {
+                'values': {E.key: 'value'},
+                'name': E.c,
+                'where': None,
+                'as': None,
+                'expected': "CREATE c:{key: 'value'}",
+            },
+            {
+                'values': {E.k: 'v'},
+                'name': '',
+                'where': None,
+                'as': None,
+                'expected': "CREATE {k: 'v'}",
+            },
+            {
+                'values': {E.k: 'v'},
+                'name': '',
+                'where': E.w,
+                'as': None,
+                'expected': "CREATE {k: 'v'} where (w)",
+            },
+            {
+                'values': {E.k: 'v'},
+                'name': '',
+                'where': None,
+                'as': 'a',
+                'expected': "CREATE {k: 'v'} as a",
+            },
+        ]
+
+        for test in cases:
+            c = Create(
+                values=test['values'],
+                name=test['name'],
+            )
+
+            if test['where']:
+                c = c.where(test['where'])
+
+            if test['as']:
+                c = c.as_(test['as'])
+
+            self.assertEqual(repr(c), test['expected'])
 
 if __name__ == '__main__':
     main()

--- a/b3j0f/requester/request/crud/test/delete.py
+++ b/b3j0f/requester/request/crud/test/delete.py
@@ -31,6 +31,7 @@ from unittest import main
 
 from b3j0f.utils.ut import UTCase
 
+from ...expr import Expression as E
 from ..delete import Delete
 
 
@@ -49,6 +50,46 @@ class DeleteTest(UTCase):
         delete = Delete(names=names)
 
         self.assertEqual(names, delete.names)
+
+    def test___repr__(self):
+        cases = [
+            {
+                'names': [E.d],
+                'where': None,
+                'as': None,
+                'expected': "DELETE d",
+            },
+            {
+                'names': [E.d1, E.d2],
+                'where': None,
+                'as': None,
+                'expected': "DELETE d1, d2",
+            },
+            {
+                'names': [E.d],
+                'where': E.w,
+                'as': None,
+                'expected': "DELETE d where (w)",
+            },
+            {
+                'names': [E.d],
+                'where': None,
+                'as': 'a',
+                'expected': "DELETE d as a",
+            },
+        ]
+
+        for test in cases:
+            d = Delete(names=test['names'])
+
+            if test['where']:
+                d = d.where(test['where'])
+
+            if test['as']:
+                d = d.as_(test['as'])
+
+            self.assertEqual(repr(d), test['expected'])
+
 
 if __name__ == '__main__':
     main()

--- a/b3j0f/requester/request/crud/test/read.py
+++ b/b3j0f/requester/request/crud/test/read.py
@@ -31,6 +31,7 @@ from unittest import main
 
 from b3j0f.utils.ut import UTCase
 
+from ...expr import Expression as E
 from ..read import Read
 
 
@@ -106,6 +107,80 @@ class ReadTest(UTCase):
         self.assertEqual((orderby,), read.orderby())
         self.assertEqual((groupby,), read.groupby())
         self.assertEqual(join, read.join())
+
+    def test___repr__(self):
+        cases = [
+            {
+                'select': None,
+                'kwargs': {},
+                'where': None,
+                'as': None,
+                'expected': "READ all",
+            },
+            {
+                'select': [E.r1, E.r2, E.r3],
+                'kwargs': {},
+                'where': None,
+                'as': None,
+                'expected': "READ r1, r2, r3",
+            },
+            {
+                'select': [E.r],
+                'kwargs': {'offset': 10},
+                'where': None,
+                'as': None,
+                'expected': "READ r with (offset 10 )",
+            },
+            {
+                'select': [E.r],
+                'kwargs': {'limit': 10},
+                'where': None,
+                'as': None,
+                'expected': "READ r with (limit 10 )",
+            },
+            {
+                'select': [E.r],
+                'kwargs': {'groupby': [E.a, E.b]},
+                'where': None,
+                'as': None,
+                'expected': "READ r with (group by a, b )",
+            },
+            {
+                'select': [E.r],
+                'kwargs': {'orderby': [E.a, E.b]},
+                'where': None,
+                'as': None,
+                'expected': "READ r with (order by a, b )",
+            },
+            {
+                'select': [E.r],
+                'kwargs': {},
+                'where': E.w,
+                'as': None,
+                'expected': "READ r where (w)",
+            },
+            {
+                'select': [E.r],
+                'kwargs': {},
+                'where': None,
+                'as': 'a',
+                'expected': "READ r as a",
+            },
+        ]
+
+        for test in cases:
+            r = Read(
+                select=test['select'],
+                **test['kwargs']
+            )
+
+            if test['where']:
+                r = r.where(test['where'])
+
+            if test['as']:
+                r = r.as_(test['as'])
+
+            self.assertEqual(repr(r), test['expected'])
 
 if __name__ == '__main__':
     main()

--- a/b3j0f/requester/request/crud/test/update.py
+++ b/b3j0f/requester/request/crud/test/update.py
@@ -31,6 +31,7 @@ from unittest import main
 
 from b3j0f.utils.ut import UTCase
 
+from ...expr import Expression as E
 from ..update import Update
 
 
@@ -44,6 +45,59 @@ class UpdateTest(UTCase):
 
         self.assertEqual('test', update.name)
         self.assertEqual(values, update.values)
+
+    def test___repr__(self):
+        cases = [
+            {
+                'values': {},
+                'name': E.u,
+                'where': None,
+                'as': None,
+                'expected': "UPDATE u:{}",
+            },
+            {
+                'values': {E.key: 'value'},
+                'name': E.u,
+                'where': None,
+                'as': None,
+                'expected': "UPDATE u:{key: 'value'}",
+            },
+            {
+                'values': {E.k: 'v'},
+                'name': '',
+                'where': None,
+                'as': None,
+                'expected': "UPDATE {k: 'v'}",
+            },
+            {
+                'values': {E.k: 'v'},
+                'name': '',
+                'where': E.w,
+                'as': None,
+                'expected': "UPDATE {k: 'v'} where (w)",
+            },
+            {
+                'values': {E.k: 'v'},
+                'name': '',
+                'where': None,
+                'as': 'a',
+                'expected': "UPDATE {k: 'v'} as a",
+            },
+        ]
+
+        for test in cases:
+            u = Update(
+                values=test['values'],
+                name=test['name'],
+            )
+
+            if test['where']:
+                u = u.where(test['where'])
+
+            if test['as']:
+                u = u.as_(test['as'])
+
+            self.assertEqual(repr(u), test['expected'])
 
 if __name__ == '__main__':
     main()

--- a/b3j0f/requester/request/crud/update.py
+++ b/b3j0f/requester/request/crud/update.py
@@ -3,7 +3,7 @@
 # --------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2016 Jonathan Labéjof <jonathan.labejof@gmail.com>
+# Copyright (c) 2016 Jonathan Labéjof <jonathan.labejof@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,7 +48,12 @@ class Update(CRUDElement):
 
     def __repr__(self):
 
-        result = 'UPDATE {0}:{1}'.format(repr(self.name), repr(self.values))
+        result = 'UPDATE '
+
+        if self.name:
+            result += '{0}:'.format(repr(self.name))
+
+        result += repr(self.values)
 
         if self.query:
             result += ' where ({0})'.format(repr(self.query))


### PR DESCRIPTION
Remplace les:
UPDATE '':{b: 2, a: 1}
CREATE u'':{a: 1, b: 2}

par des:
UPDATE {b: 2, a: 1}
CREATE {b: 2, a: 1}